### PR TITLE
feat : 소셜로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/aibe/hosik/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/aibe/hosik/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,29 @@
+package aibe.hosik.auth;
+
+import java.io.IOException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws ServletException, IOException {
+        String authHeader = req.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            if (jwtTokenProvider.validateToken(token)) {
+                Authentication auth = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+        chain.doFilter(req, res);
+    }
+}

--- a/src/main/java/aibe/hosik/auth/JwtTokenProvider.java
+++ b/src/main/java/aibe/hosik/auth/JwtTokenProvider.java
@@ -1,0 +1,70 @@
+package aibe.hosik.auth;
+
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.java.Log;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+
+@Component
+@Log
+public class JwtTokenProvider {
+    @Value("${jwt.secret}")
+    private String secretKey;
+    @Value("${jwt.expiration-ms}")
+    private long expirationMs;
+
+    public SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    public String generateToken(Authentication authentication) {
+        String username = authentication.getName();
+        Instant now = Instant.now();
+        Date expiration = new Date(now.toEpochMilli() + expirationMs);
+
+        return Jwts.builder()
+                .subject(username)
+                .issuedAt(Date.from(now))
+                .expiration(expiration)
+                .signWith(getSecretKey(), Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parser()
+                .verifyWith(getSecretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(getSecretKey())
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public UsernamePasswordAuthenticationToken getAuthentication(String token) {
+        UserDetails user = new User(getUsername(token), "", Collections.emptyList());
+        return new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+    }
+}

--- a/src/main/java/aibe/hosik/auth/SecurityConfig.java
+++ b/src/main/java/aibe/hosik/auth/SecurityConfig.java
@@ -1,0 +1,95 @@
+package aibe.hosik.auth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+/**
+ * 보안 설정 클래스 
+ */
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@Log
+public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${front-end.redirect}")
+    private String frontEndRedirect;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            // CSRF 비활성화 (REST 전용)
+            .csrf(csrf -> csrf.disable())
+            // 기본 CORS 설정
+            .cors(cors -> cors.configurationSource(req -> new CorsConfiguration().applyPermitDefaultValues()))
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            // URL 권한 설정
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/oauth2/**").permitAll()           // OAuth2 콜백
+                .requestMatchers("/api/data/**").authenticated()    // 인증 필요 API
+                .anyRequest().permitAll()                             // 나머지 허용
+            )
+            // OAuth2 로그인 설정
+            .oauth2Login(oauth2 -> oauth2
+                .loginPage("/oauth2/authorization/kakao")           // OAuth2 로그인 진입점
+                .successHandler(oauth2SuccessHandler())               // 로그인 성공 후 처리
+            )
+            // JWT 인증 필터 등록
+            .addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    /**
+     * JWT 인증 필터 빈 등록
+     */
+    @Bean
+    public JwtAuthenticationFilter jwtFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider);
+    }
+
+    /**
+     * OAuth2 로그인 성공 시 JWT 발급 및 리다이렉트 핸들러
+     */
+    @Bean
+    public AuthenticationSuccessHandler oauth2SuccessHandler() {
+        return (request, response, authentication) -> {
+            var oauthToken = (org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken) authentication;
+            String regId = oauthToken.getAuthorizedClientRegistrationId();
+            var user = oauthToken.getPrincipal();
+
+            String username;
+            if ("github".equals(regId)) {
+                username = "github_" + user.getAttribute("login");
+            } else {
+                username = "kakao_" + user.getAttribute("id").toString();
+            }
+
+            // JWT 생성
+            String token = jwtTokenProvider.generateToken(
+                new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(username, "")
+            );
+
+            // 프론트엔드로 전달
+            String redirectUrl = UriComponentsBuilder.fromUriString(frontEndRedirect)
+                .queryParam("token", token)
+                .build().toUriString();
+            response.sendRedirect(redirectUrl);
+        };
+    }
+}

--- a/src/main/java/aibe/hosik/model/entity/GithubUser.java
+++ b/src/main/java/aibe/hosik/model/entity/GithubUser.java
@@ -1,0 +1,24 @@
+package aibe.hosik.model.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GithubUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String username;
+    private String name;
+    private String email;
+}

--- a/src/main/java/aibe/hosik/model/entity/KakaoUser.java
+++ b/src/main/java/aibe/hosik/model/entity/KakaoUser.java
@@ -1,0 +1,24 @@
+package aibe.hosik.model.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String username;
+    private String name;
+    private String email;
+}

--- a/src/main/java/aibe/hosik/model/repository/GithubUserRepository.java
+++ b/src/main/java/aibe/hosik/model/repository/GithubUserRepository.java
@@ -1,0 +1,12 @@
+package aibe.hosik.model.repository;
+
+import aibe.hosik.model.entity.GithubUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface GithubUserRepository extends JpaRepository<GithubUser, Long> {
+    Optional<GithubUser> findByUsername(String username);
+}

--- a/src/main/java/aibe/hosik/model/repository/KakaoUserRepository.java
+++ b/src/main/java/aibe/hosik/model/repository/KakaoUserRepository.java
@@ -1,0 +1,12 @@
+package aibe.hosik.model.repository;
+
+import aibe.hosik.model.entity.KakaoUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface KakaoUserRepository extends JpaRepository<KakaoUser, Long> {
+    Optional<KakaoUser> findByUsername(String username);
+}

--- a/src/main/java/aibe/hosik/service/CustomOAuth2UserService.java
+++ b/src/main/java/aibe/hosik/service/CustomOAuth2UserService.java
@@ -1,0 +1,138 @@
+package aibe.hosik.service;
+
+import aibe.hosik.auth.JwtTokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import aibe.hosik.model.entity.KakaoUser;
+import aibe.hosik.model.entity.GithubUser;
+import aibe.hosik.model.repository.KakaoUserRepository;
+import aibe.hosik.model.repository.GithubUserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Log
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+    private final GithubUserRepository githubUserRepository;
+    private final KakaoUserRepository kakaoUserRepository;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 실제 OAuth2 프로바이더에서 유저 정보를 가져오는 기본 서비스 호출
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // (kakao or github) 로그인했는지 구분
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        if ("kakao".equals(registrationId)) {
+            //  기존 카카오 로직
+            Map<String, Object> attributes = oAuth2User.getAttributes();
+            Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+            Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
+
+            String kakaoId = attributes.get("id").toString();
+            String nickname = kakaoProfile.get("nickname").toString();
+            String kakaoUsername = "kakao_" + kakaoId;
+
+            // 카카오 유저 저장 또는 조회
+            KakaoUser kakaoUser = kakaoUserRepository.findByUsername(kakaoUsername)
+                    .orElseGet(() -> {
+                        KakaoUser u = new KakaoUser();
+                        u.setUsername(kakaoUsername);
+                        u.setName(nickname);
+                        return kakaoUserRepository.save(u);
+                    });
+
+            log.info("Kakao login: " + kakaoUser);
+        } else if ("github".equals(registrationId)) {
+            // GitHub 로직
+            Map<String, Object> attrs = oAuth2User.getAttributes();
+
+            String githubLogin = (String) attrs.get("login");
+            String githubName = (String) attrs.get("name");
+            String githubUsername = "github_" + githubLogin;
+
+            // GitHub 유저 저장 또는 조회
+            GithubUser githubUser = githubUserRepository.findByUsername(githubUsername)
+                    .orElseGet(() -> {
+                        GithubUser u = new GithubUser();
+                        u.setUsername(githubUsername);
+                        u.setName(githubName);
+                     //   u.setRole("GITHUB");
+                        return githubUserRepository.save(u);
+                    });
+
+            log.info("GitHub login: " + githubUser);
+        }
+
+        // 스프링 시큐리티가 사용할 OAuth2User 반환
+        return oAuth2User;
+    }
+
+    @Service
+    @RequiredArgsConstructor
+    public static class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+        private final JwtTokenProvider jwtTokenProvider;
+
+        @Value("${front-end.redirect}")
+        private String frontEndRedirect;
+
+        @Override
+        public void onAuthenticationSuccess(HttpServletRequest req,
+                                            HttpServletResponse res,
+                                            Authentication authentication)
+                throws IOException, ServletException {
+            // 1) OAuth2AuthenticationToken으로 캐스팅해서 registrationId 가져오기
+            var oauthToken = (OAuth2AuthenticationToken) authentication;
+            String regId = oauthToken.getAuthorizedClientRegistrationId(); // "kakao" 또는 "github"
+
+            // 2) OAuth2User 정보
+            OAuth2User oAuth2User = oauthToken.getPrincipal();
+
+            String username;
+
+            if ("github".equals(regId)) {
+                //  GitHub 로그인
+                // GitHub API 응답에서 주요 속성 꺼내기
+                String githubLogin = oAuth2User.getAttribute("login");
+                username = "github_" + githubLogin;
+            } else {
+                // Kakao 로그인
+                String id = oAuth2User.getAttribute("id").toString();
+                username = "kakao_" + id;
+            }
+
+            // 3) JWT 토큰 생성
+            String token = jwtTokenProvider.generateToken(
+                    new UsernamePasswordAuthenticationToken(username, "")
+            );
+
+            // 4) 프론트엔드로 토큰 전달 (쿼리 파라미터)
+            String redirectUrl = UriComponentsBuilder
+                    .fromUriString(frontEndRedirect)
+                    .queryParam("token", token)
+                    .build().toUriString();
+
+            res.sendRedirect(redirectUrl);
+        }
+    }
+}

--- a/src/main/java/aibe/hosik/service/CustomUserDetailsService.java
+++ b/src/main/java/aibe/hosik/service/CustomUserDetailsService.java
@@ -1,0 +1,45 @@
+package aibe.hosik.service;
+
+import aibe.hosik.model.entity.GithubUser;
+import aibe.hosik.model.entity.KakaoUser;
+import aibe.hosik.model.entity.LocalUser;
+import aibe.hosik.model.repository.GithubUserRepository;
+import aibe.hosik.model.repository.KakaoUserRepository;
+import aibe.hosik.model.repository.LocalUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Log
+public class CustomUserDetailsService implements UserDetailsService {
+    private final KakaoUserRepository kakaoUserRepository;
+    private final GithubUserRepository GithubUserRepository;
+    private final LocalUserRepository localUserRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        if (username.startsWith("kakao_")) {
+            //  카카오 로그인 유저
+            KakaoUser account = kakaoUserRepository.findByUsername(username)
+                    .orElseThrow(() -> new UsernameNotFoundException("유저가 없습니다: " + username));
+            return User.builder()
+                    .username(account.getUsername())
+                    .password("")  // OAuth2 로그인은 패스워드 미사용
+                    .build();
+        }else if (username.startsWith("github_")) {
+            //  깃허브 로그인 유저
+            GithubUser account = GithubUserRepository.findByUsername(username)
+                    .orElseThrow(() -> new UsernameNotFoundException("유저가 없습니다: " + username));
+            return User.builder()
+                    .username(account.getUsername())
+                    .password("")  // OAuth2 로그인은 패스워드 미사용
+                    .build();
+        }
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,56 @@
+server:
+  port: 8080
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id:
+            client-secret:
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            scope:
+              - profile_nickname
+             # - account_email
+          github:
+            client-id:
+            client-secret:
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/github"
+            scope:
+              - read:user
+              - user:email
+        provider:
+          kakao:
+            authorization-uri:  https://kauth.kakao.com/oauth/authorize
+            token-uri:          https://kauth.kakao.com/oauth/token
+            user-info-uri:      https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          github:
+            authorization-uri:  https://github.com/login/oauth/authorize
+            token-uri:          https://github.com/login/oauth/access_token
+            user-info-uri:      https://api.github.com/user
+            user-name-attribute: id
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url:
+    username:
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+springdoc:
+  swagger-ui:
+    enabled: true
+  api-docs:
+    enabled: true
+jwt:
+  secret:
+  expiration-ms: 3600000  # 1시간
+front-end:
+  redirect: http://localhost:3000/oauth2/redirect


### PR DESCRIPTION
## #️⃣연관된 이슈

>#16 

## 📝작업 내용
### 기능 구현
- 소셜 로그인 구현(카카오, 깃허브)
- CustomOAuth2UserService 사용해서 카카오인지 깃허브인지 구분

### 개선
- 카카오 로그인은 되는데 페이지가 하나로 고정돼 있어서 오류가 나는 것 같음 프론트랑 연결해서 테스트가 필요


## 💬리뷰 요구사항(선택) 및 기타 참고사항

- model 부분의 수정을 어떻게 해야 할까요?


## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다
