### PR TITLE
fix : JWT + 모집글 인증 연결 및 댓글 유저 인증 추가

### DIFF
--- a/src/main/java/aibe/hosik/comment/controller/CommentController.java
+++ b/src/main/java/aibe/hosik/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import aibe.hosik.comment.entity.Comment;
 import aibe.hosik.comment.service.CommentService;
 import aibe.hosik.user.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -24,9 +26,13 @@ import java.util.List;
 public class CommentController {
   private final CommentService commentService;
 
+  @SecurityRequirement(name = "JWT")
   @Operation(summary="댓글 등록", description="댓글 및 대댓글을 등록합니다.")
   @PostMapping
   public ResponseEntity<?> createComment(@RequestBody CommentRequestDTO dto, @AuthenticationPrincipal User user) {
+    if (user == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+    }
     commentService.createComment(dto, user);
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
@@ -38,18 +44,26 @@ public class CommentController {
     return ResponseEntity.ok(comments);
   }
 
+  @SecurityRequirement(name = "JWT")
   @Operation(summary="댓글 삭제", description="댓글을 삭제합니다.")
   @DeleteMapping("/{commentId}")
   public ResponseEntity<?> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal User user) {
+    if (user == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+    }
     commentService.deleteComment(commentId, user);
     return ResponseEntity.noContent().build();
   }
 
+  @SecurityRequirement(name = "JWT")
   @Operation(summary = "댓글 수정", description = "댓글을 수정합니다.")
   @PatchMapping("/{commentId}")
   public ResponseEntity<?> updateComment(@PathVariable Long commentId,
                                          @RequestBody CommentRequestDTO dto,
                                          @AuthenticationPrincipal User user) {
+    if (user == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+    }
     commentService.updateComment(commentId, dto, user);
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/aibe/hosik/post/dto/PostPatchDTO.java
+++ b/src/main/java/aibe/hosik/post/dto/PostPatchDTO.java
@@ -10,7 +10,6 @@ public record PostPatchDTO(
         String title,
         String content,
         Integer headCount,
-        String image,
         String requirementPersonality,
         LocalDate endedAt,
 

--- a/src/main/java/aibe/hosik/post/dto/PostResponseDTO.java
+++ b/src/main/java/aibe/hosik/post/dto/PostResponseDTO.java
@@ -10,6 +10,7 @@ public record PostResponseDTO(
         String title,
         String content,
         String category,
+        String type,
         List<String> skills,
         Integer headCount,
         Integer currentCount
@@ -21,6 +22,7 @@ public record PostResponseDTO(
                 post.getTitle(),
                 post.getContent(),
                 post.getCategory().toString(),
+                post.getType().toString(),
                 skills,
                 post.getHeadCount(),
                 currentCount

--- a/src/main/java/aibe/hosik/post/entity/Post.java
+++ b/src/main/java/aibe/hosik/post/entity/Post.java
@@ -65,7 +65,6 @@ public class Post extends TimeEntity {
   public void updatePatch(PostPatchDTO dto) {
     if (dto.title() != null) this.title = dto.title();
     if (dto.content() != null) this.content = dto.content();
-    if (dto.image() != null) this.image = dto.image();
     if (dto.requirementPersonality() != null) this.requirementPersonality = dto.requirementPersonality();
     if (dto.headCount() != null) this.headCount = dto.headCount();
     if (dto.endedAt() != null) this.endedAt = dto.endedAt();


### PR DESCRIPTION
## #️⃣연관된 이슈

#34 

## 📝작업 내용
- PostController의 Update 메서드 이미지 수정 로직 및 유저 인증 추가
  - 모집글 작성 유저만 수정할 수 있게 구현
  - 이미지 부분 수정도 가능하게 변경
  - Type, Category enum으로 변경
- CommentController JWT 인증 추가
  - 댓글 등록 / 수정 / 삭제 시에도 유저 인증(로그인한 유저) 추가

## 🔧 테스트
- 게시글 등록 / 수정 / 삭제 / 조회 테스트 완료
![image](https://github.com/user-attachments/assets/97e48f8c-f77c-4595-8ccb-15240a07d645)
![image](https://github.com/user-attachments/assets/62c2dca9-6089-4682-ab9a-583db37c49c1)

- 댓글 및 대댓글 등록 / 수정 / 삭제 / 조회 테스트 완료


## 💬리뷰 요구사항(선택) 및 기타 참고사항
- Controller 부분에 `RequestParam`과 `dto` 변경 중복 코드가 있어 리팩터링 방법 찾아보겠습니다
- JWT 인증 관련 로직이 잘 되어 있는지 확인 부탁드립니다



## ✅ 체크리스트

- [x] 코드 점검 완료했습니다
- [x] 문서/주석 최신화 완료했습니다
