### PR TITLE
fix : github Actions 배포 시 발생하는 502 에러 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,18 +138,23 @@ jobs:
           ssh -o StrictHostKeyChecking=no ec2-user@${{ secrets.EC2_HOST }} << EOF
           cd ~/teamo
 
-          # 디렉토리 구조 확인
-          mkdir -p ./nginx/certbot
-          mkdir -p ./nginx/www
-          
-          # 기존 컨테이너 중지
-          docker rm -f teamo certbot || true
-          
           # 최신 이미지 가져오기
           docker pull hosiki/teamo:latest
+    
+          # Spring Boot 서비스만 먼저 재시작
+          docker-compose stop teamo
+          docker-compose rm -f teamo
+          docker-compose up -d teamo
           
-          # 서비스 시작
-          docker-compose up -d
+          # Spring Boot 애플리케이션 시작 대기
+          echo "Spring Boot 애플리케이션 시작 대기 중..."
+          sleep 20
+          
+          # Nginx 재시작 (Spring Boot 서비스에 의존)
+          docker-compose restart nginx
+          
+          # 컨테이너 상태 확인
+          docker ps
           
           # 불필요한 이미지 정리
           docker image prune -f


### PR DESCRIPTION
## #️⃣연관된 이슈

#73

## 📝작업 내용
- 자동 배포 후 502 Bad Gateway 오류 발생 
   - Spring Boot 애플리케이션 완전 초기화 전 Nginx 요청 전달 시도
   - Spring Boot 컨테이녀 먼저 시작 후 20초 대기. Nginx 재시작 

## 💬리뷰 요구사항(선택) 및 기타 참고사항
- 자동 배포 후 테스트 부탁드립니다

## ✅ 체크리스트

- [x] 코드 점검 완료했습니다
- [x] 문서/주석 최신화 완료했습니다
