### PR TITLE
fix : 게시글 조회 시 N+1 문제 해결

### DIFF
--- a/src/main/java/aibe/hosik/apply/repository/ApplyRepository.java
+++ b/src/main/java/aibe/hosik/apply/repository/ApplyRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
@@ -29,6 +30,9 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
      * @return 선정된 지원자 수
      */
     int countByPostIdAndIsSelectedTrue(Long postId);
+
+    @Query("SELECT a.post.id as postId, COUNT(a) as count FROM Apply a WHERE a.isSelected = true GROUP BY a.post.id")
+    List<Map<String, Object>> countSelectedAppliesByPostId();
 
     /**
      * 특정 모집글에 지원한 지원자들과 그들의 이력서, 프로필 및 분석 결과를 함께 조회한다.

--- a/src/main/java/aibe/hosik/post/entity/Post.java
+++ b/src/main/java/aibe/hosik/post/entity/Post.java
@@ -8,6 +8,7 @@ import aibe.hosik.skill.entity.PostSkill;
 import aibe.hosik.user.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -59,10 +60,12 @@ public class Post extends TimeEntity {
 
   // 양방향 매핑
   @OneToMany(mappedBy = "post")
+  @BatchSize(size=20)
   @Builder.Default
   private List<PostSkill> postSkills = new ArrayList<>();
 
   @OneToMany(mappedBy = "post")
+  @BatchSize(size=20)
   @Builder.Default
   private List<Apply> applies = new ArrayList<>();
 

--- a/src/main/java/aibe/hosik/post/repository/PostRepository.java
+++ b/src/main/java/aibe/hosik/post/repository/PostRepository.java
@@ -13,9 +13,19 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     // Post 조회 시 postSkills, skill 엔티티 즉시 로딩 지정
-    //@EntityGraph(attributePaths = {"postSkills", "postSkills.skill"})
+    @EntityGraph(attributePaths = {"postSkills", "postSkills.skill"})
     @Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.postSkills ps LEFT JOIN FETCH ps.skill")
     List<Post> findAllWithSkills();
+
+    @Query("""
+        SELECT DISTINCT p FROM Post p 
+        LEFT JOIN FETCH p.postSkills ps 
+        LEFT JOIN FETCH ps.skill s
+        LEFT JOIN FETCH p.applies a
+        LEFT JOIN FETCH a.user
+        WHERE a.isSelected = true
+        """)
+    List<Post> findAllWithSkillsAndSelectedApplies();
 
     @Query("""
         SELECT DISTINCT p 


### PR DESCRIPTION
## #️⃣연관된 이슈

#79 

## 📝작업 내용

- `GET /post` 시에 발생하는 N+1 문제 해결
- EntityGraph와 BatchSize 적용으로 연관 엔티티 일괄 로딩 구현

## 💬리뷰 요구사항(선택) 및 기타 참고사항
배포 환경에서 테스트 및 쿼리 로그 확인 부탁드립니당

## ✅ 체크리스트

- [x] 코드 점검 완료했습니다
- [x] 문서/주석 최신화 완료했습니다
